### PR TITLE
Meta-tags middleware

### DIFF
--- a/src/Router/DocumentMetaMiddleware.ts
+++ b/src/Router/DocumentMetaMiddleware.ts
@@ -1,0 +1,103 @@
+import { Middleware } from './Middleware';
+import { Request } from './Request';
+import { Meta, Response } from './Response';
+
+export type TitleBuilder = (title: string | undefined, response: Response) => string;
+export type MetaBuilder = (meta: Meta|undefined, response: Response) => Meta;
+
+/**
+ * Middleware to set the document title and meta tags upon navigation.
+ */
+export class DocumentMetaMiddleware extends Middleware{
+    /**
+     * Get the owner document.
+     */
+    protected document?: Document;
+
+    /**
+     * Title builder function.
+     */
+    protected titleBuilder: TitleBuilder;
+
+    /**
+     * Meta builder function.
+     */
+    protected metaBuilder: MetaBuilder;
+
+    /**
+     * Meta tags from last invocation.
+     */
+    protected currentMeta: Meta = {};
+
+    /**
+     * Middleware rule constructor.
+     * @param document The owner document.
+     * @param titleBuilder The title builder function.
+     * @param metaBuilder The meta builder function.
+     */
+    public constructor(document: Document | undefined = window.document, titleBuilder?: TitleBuilder, metaBuilder?: MetaBuilder) {
+        super({});
+
+        this.document = document;
+        this.titleBuilder = titleBuilder || ((title) => title || '');
+        this.metaBuilder = metaBuilder || ((meta) => meta || {});
+    }
+
+    /**
+     * Set document title and meta tags.
+     * @inheritdoc
+     */
+    public hookAfter(request: Readonly<Request>, response: Response): Response {
+        this.setTitle(this.titleBuilder(response.title, response));
+        this.setMeta(this.metaBuilder(response.meta, response));
+
+        return response;
+    }
+
+    /**
+     * Update title.
+     * @param string The title string.
+     */
+    protected setTitle(title: string): void {
+        if (this.document === undefined) {
+            return;
+        }
+
+        this.document.title = title;
+    }
+
+    /**
+     * Update meta tags.
+     * @param current Metadata for current state.
+     * @param previous Previous metadata.
+     */
+    protected setMeta(meta: Meta): void {
+        if (this.document === undefined) {
+            return;
+        }
+
+        const head = this.document.head;
+        Object.entries(meta).forEach(([name, content]) => {
+            let meta = head.querySelector(`meta[name="${name}"]`);
+            if (meta !== null) {
+                meta.setAttribute('content', content);
+
+                return;
+            }
+
+            meta = head.ownerDocument.createElement('meta');
+            meta.setAttribute('name', name);
+            meta.setAttribute('content', content);
+            head.appendChild(meta);
+        });
+
+        Object.keys(this.currentMeta)
+            .filter((name) => !(name in meta))
+            .forEach((name) => {
+                const meta = head.querySelector(`meta[name="${name}"]`);
+                if (meta !== null) {
+                    meta.remove();
+                }
+            });
+    }
+}

--- a/src/Router/DocumentMetaMiddleware.ts
+++ b/src/Router/DocumentMetaMiddleware.ts
@@ -1,6 +1,6 @@
 import { Middleware } from './Middleware';
-import { Request } from './Request';
-import { Meta, Response } from './Response';
+import type { Request } from './Request';
+import type { Meta, Response } from './Response';
 
 export type TitleBuilder = (title: string | undefined, response: Response) => string;
 export type MetaBuilder = (meta: Meta|undefined, response: Response) => Meta;
@@ -8,7 +8,7 @@ export type MetaBuilder = (meta: Meta|undefined, response: Response) => Meta;
 /**
  * Middleware to set the document title and meta tags upon navigation.
  */
-export class DocumentMetaMiddleware extends Middleware{
+export class DocumentMetaMiddleware extends Middleware {
     /**
      * Get the owner document.
      */

--- a/src/Router/Response.ts
+++ b/src/Router/Response.ts
@@ -11,6 +11,11 @@ import { Request } from './Request';
 export type View = (request: Request, response: Response) => Template;
 
 /**
+ * A set of metatags to be set on the page.
+ */
+export type Meta = { [key: string]: string };
+
+/**
  * A class representing the response for a new page request in the app.
  */
 export class Response {
@@ -39,10 +44,39 @@ export class Response {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     public data: any;
 
+    protected _title?: string|undefined;
+
     /**
      * The title of the response.
      */
-    public title?: string;
+    public get title(): string|undefined {
+        return this._childResponse?.title ?? this._title;
+    }
+
+    /**
+     * Set the title of the response.
+     * @deprecated Use setTitle() instead.
+     */
+    public set title(title: string|undefined) {
+        this.setTitle(title);
+    }
+
+    protected _meta?: Meta|undefined;
+
+    /**
+     * The metadata associated to the response.
+     */
+    public get meta(): Meta|undefined {
+        return this._childResponse?.meta ?? this._meta;
+    }
+
+    /**
+     * Set the metadata associated to the response.
+     * @deprecated Use setMeta() instead.
+     */
+    public set meta(meta: Meta|undefined) {
+        this.setMeta(meta);
+    }
 
     /**
      * The view of the response.
@@ -102,8 +136,22 @@ export class Response {
      * Set the title of the Response.
      * @param title The string to set.
      */
-    setTitle(title: string) {
-        this.title = title;
+    setTitle(title: string|undefined) {
+        this._title = title;
+        if (this._childResponse) {
+            this._childResponse.setTitle(title);
+        }
+    }
+
+    /**
+     * Set metadata to be associated to the response.
+     * @param meta The metadata to set.
+     */
+    setMeta(meta: Meta|undefined) {
+        this._meta = meta;
+        if (this._childResponse) {
+            this._childResponse.setMeta(meta);
+        }
     }
 
     /**

--- a/src/Router/Router.ts
+++ b/src/Router/Router.ts
@@ -522,9 +522,6 @@ export class Router extends Factory.Emitter {
         this.index = state.index;
         this.states.splice(state.index, this.states.length, state);
         if (this.history) {
-            if (this.history === window.history) {
-                window.document.title = state.title;
-            }
             this.history.pushState({
                 id: state.id,
                 url: state.url,
@@ -551,9 +548,6 @@ export class Router extends Factory.Emitter {
         const previous = this.states[this.index];
         this.states.splice(state.index, this.states.length, state);
         if (this.history) {
-            if (this.history === window.history) {
-                window.document.title = state.title;
-            }
             this.history.replaceState({
                 id: state.id,
                 url: state.url,
@@ -584,9 +578,6 @@ export class Router extends Factory.Emitter {
         } else {
             state = this.states[newState.index];
             this.index = newState.index;
-        }
-        if (this.history === window.history) {
-            window.document.title = state.title;
         }
         await this.trigger('popstate', {
             previous,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,4 @@ export { History } from './Router/History';
 export { Router } from './Router/Router';
 export { App } from './App';
 export * from './helpers';
+export { DocumentMetaMiddleware } from './Router/DocumentMetaMiddleware';


### PR DESCRIPTION
This pull request:

* introduces a new field `meta` on the Response object, alongside a setter method `setMedia()`.
* changes the way `title` is read from the Response object: it now returns the child Response's title if it's present, and parent Response's title is unset
* `window.title` is no longer being set by Router itself, and that piece of logic has been moved to a specialized DocumentMetaMiddleware, which takes care of setting the document's title _and_ its meta-tags

Being `DocumentMetaMiddleware` the first middleware exported by this package, I was wondering if this is the right place for it to be, or it should rather belong to another package.